### PR TITLE
Verhindern, dass TK Inter doppelt eingebunden wird.

### DIFF
--- a/3.0_Rahmen.py
+++ b/3.0_Rahmen.py
@@ -1,4 +1,3 @@
-from tkinter import *
 import tkinter as tk
 
 # Erstelle das Hauptfenster
@@ -8,10 +7,10 @@ root.geometry("400x300")
 
 
 # Einen Frame Zeichen
-logo_frame = Frame(root,background="yellow")
+logo_frame = tk.Frame(root,background="yellow")
 logo_frame.pack(fill="both",expand=True,side='left')
 # Einen Frame Zeichen
-stat_frame = Frame(root,background="cyan")
+stat_frame = tk.Frame(root,background="cyan")
 stat_frame.pack(fill="both",expand=True,side='left')
 
 


### PR DESCRIPTION
Entfernen von "from module import *", bei grösseren Projekten werden solche Imports unübersichtlich, weil man dann nicht mehr weiss das "Frame" ein Teil von tkinter ist.

Ich denke auch für ein Tutorial ist es besser, wenn man sieht das Frame eine Funktion von tkinter ist.